### PR TITLE
Add workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:35"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "10:35"

--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -1,0 +1,18 @@
+name: TUF-on-CI create Signing events
+
+on:
+  schedule:
+    - cron:  '17 1,7,13,19 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  create-signing-events:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'write' # for committing to signing event branch
+      actions: 'write' # for dispatching signing event workflow
+    steps:
+      - name: Create signing events for offline version bumps
+        uses: theupdateframework/tuf-on-ci/actions/create-signing-events@6d32b9491bcccdf75b64f4c779f0366ad0e35b7e # v0.1.0

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -1,0 +1,27 @@
+name: TUF-on-CI online signing
+
+permissions: {}
+
+on:
+  schedule:
+    - cron:  '17 1,7,13,19 * * *'
+  push:
+    branches: [ main ]
+    paths: ['metadata/**']
+  workflow_dispatch:
+
+jobs:
+  online-sign:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: 'write' # for OIDC identity access
+      contents: 'write' # for commiting snapshot/timestamp changes
+      actions: 'write' # for dispatching publish workflow
+
+    steps:
+      - id: online-sign
+        uses: theupdateframework/tuf-on-ci/actions/online-sign@6d32b9491bcccdf75b64f4c779f0366ad0e35b7e # v0.1.0
+        with:
+          gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: TUF-on-CI publish to GitHub Pages
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - id: build-and-upload-repository
+        uses: theupdateframework/tuf-on-ci/actions/upload-repository@6d32b9491bcccdf75b64f4c779f0366ad0e35b7e # v0.1.0
+        with:
+          gh_pages: true
+
+  deploy:
+    permissions:
+      pages: write
+      id-token: write # for authenticating to GH Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy TUF-on-CI repository to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@9dbe3824824f8a1377b8e298bafde1a50ede43e5 # v2.0.4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
         uses: theupdateframework/tuf-on-ci/actions/upload-repository@6d32b9491bcccdf75b64f4c779f0366ad0e35b7e # v0.1.0
         with:
           gh_pages: true
+          metadata_path: './'
 
   deploy:
     permissions:

--- a/.github/workflows/signing-event.yml
+++ b/.github/workflows/signing-event.yml
@@ -1,0 +1,20 @@
+name: TUF-on-CI signing event
+
+permissions: {}
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['sign/**']
+    paths: ['metadata/**', 'targets/**']
+
+jobs:
+  handle-signing-event:
+    name: TUF-on-CI signing event
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # for adding targets changes into the signing event branch
+      issues: write
+    steps:
+      - name: Signing event
+        uses: theupdateframework/tuf-on-ci/actions/signing-event@6d32b9491bcccdf75b64f4c779f0366ad0e35b7e # v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# root-signing-staging
+## Sigstore root-signing-staging
+
+Sigstore uses a TUF repository as the delivery mechanism for the keys and certificates
+that Sigstore clients need. Please see [root-signing](https://github.com/sigstore/root-signing).
+
+This project maintains a **staging** version of the root-signing TUF repository using
+[tuf-on-ci](https://github.com/theupdateframework/tuf-on-ci): this is a development and testing
+resource and should never be used as an actual source of truth by Sigstore clients.
+
+### Status
+
+root-signing-staging is not yet ready for use:
+* Project is currently being setup and is not fully functional
+* While the plan is to eventually maintain root-signing with the same processes as
+  root-signing-staging, this is not currently the case
+
+### Contact
+
+* Feel free to file an issue on this project
+* [tuf-on-ci](https://github.com/theupdateframework/tuf-on-ci) issue tracking may be
+  most useful for software issues, 
+  [tuf-on-ci slack channel](https://cloud-native.slack.com/archives/C04SHK2DPK9)
+  on CNCF slack works too


### PR DESCRIPTION
Setup a tuf-on-ci running repository

* Copy workflows from tuf-on-ci-template
* Make sigstore specific tweaks to publishing paths in the workflows
* Add a barebones README

I kind of suspect these workflows won't work quite out of the box (as in the repository settings may need tweaking) but I think this is the way to find out

