### PR TITLE
Revert "build(deps): bump actions/deploy-pages from 3.0.1 to 4.0.0"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,4 @@ jobs:
     steps:
       - name: Deploy TUF-on-CI repository to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@f33f41b675f0ab2dc5a6863c9a170fe83af3571e # v4.0.0
+        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3.0.1


### PR DESCRIPTION
This reverts commit 4de5f40af7b0aa54866167bd9e59003a28e870a9.

* as the release notes mentioned this requires actions/upload-pages-artifact@v3: tuf-on-ci does not use that yet
* The release also broke the whole Pages deploy pipeline: v4 does not seem to work anywhere right now

upload-pages-artifact can be upgraded with tuf-on-ci 0.4 (the next release).