### PR TITLE
workflows: Upgrade to tuf-on-ci 0.4 Release Candidate

### DIFF
--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -15,4 +15,6 @@ jobs:
       actions: 'write' # for dispatching signing event workflow
     steps:
       - name: Create signing events for offline version bumps
-        uses: theupdateframework/tuf-on-ci/actions/create-signing-events@d5496b4dfa28a02eec0d8ac1bb228ea08d3f7c1a # v0.3.0
+        uses: theupdateframework/tuf-on-ci/actions/create-signing-events@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -7,7 +7,7 @@ on:
     - cron:  '17 1,7,13,19 * * *'
   push:
     branches: [ main ]
-    paths: ['metadata/**']
+    paths: ['metadata/**', '!metadata/timestamp.json', '!metadata/snapshot.json']
   workflow_dispatch:
 
 jobs:
@@ -21,7 +21,8 @@ jobs:
 
     steps:
       - id: online-sign
-        uses: theupdateframework/tuf-on-ci/actions/online-sign@d5496b4dfa28a02eec0d8ac1bb228ea08d3f7c1a # v0.3.0
+        uses: theupdateframework/tuf-on-ci/actions/online-sign@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
         with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: build-and-upload-repository
-        uses: theupdateframework/tuf-on-ci/actions/upload-repository@d5496b4dfa28a02eec0d8ac1bb228ea08d3f7c1a # v0.3.0
+        uses: theupdateframework/tuf-on-ci/actions/upload-repository@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
         with:
           gh_pages: true
           ref: ${{ inputs.ref }}
@@ -34,4 +34,4 @@ jobs:
     steps:
       - name: Deploy TUF-on-CI repository to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3.0.1
+        uses: actions/deploy-pages@7a9bd943aa5e5175aeb8502edcc6c1c02d398e10 # v4.0.2

--- a/.github/workflows/signing-event.yml
+++ b/.github/workflows/signing-event.yml
@@ -15,6 +15,9 @@ jobs:
     permissions:
       contents: write # for adding targets changes into the signing event branch
       issues: write
+      actions: write # for dispatching another signing-event workflow
     steps:
       - name: Signing event
-        uses: theupdateframework/tuf-on-ci/actions/signing-event@d5496b4dfa28a02eec0d8ac1bb228ea08d3f7c1a # v0.3.0
+        uses: theupdateframework/tuf-on-ci/actions/signing-event@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Upgrade to tuf-on-ci 0.4 RC to get
* custom token support
* support for deploy-pages v4

This is going to be a final test for tuf-on-ci 0.4 (since the custom
token support is pretty much impossible to finally test without a GitHub
org that is sufficiently locked down).
* If everything works out we release tuf-on-ci 0.4 as is
* Then root-signing-staging upgrades to real tuf-on-ci 0.4
