### PR TITLE
Upgrade tuf-on-ci actions to 0.4.0

### DIFF
--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -15,6 +15,6 @@ jobs:
       actions: 'write' # for dispatching signing event workflow
     steps:
       - name: Create signing events for offline version bumps
-        uses: theupdateframework/tuf-on-ci/actions/create-signing-events@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/create-signing-events@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - id: online-sign
-        uses: theupdateframework/tuf-on-ci/actions/online-sign@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/online-sign@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: build-and-upload-repository
-        uses: theupdateframework/tuf-on-ci/actions/upload-repository@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/upload-repository@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
         with:
           gh_pages: true
           ref: ${{ inputs.ref }}

--- a/.github/workflows/signing-event.yml
+++ b/.github/workflows/signing-event.yml
@@ -16,8 +16,9 @@ jobs:
       contents: write # for adding targets changes into the signing event branch
       issues: write
       actions: write # for dispatching another signing-event workflow
+
     steps:
       - name: Signing event
-        uses: theupdateframework/tuf-on-ci/actions/signing-event@6e6d3fbf63d714721cd6a693b2b9f599ebd94f19 # rc-v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/signing-event@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a really minor bump as we were on the release candidate already.

Also make a few whitespace tweaks to make sure the workflows match the ones in tuf-on-ci-template: now the "diff" from there shows only the added metadata_path argument to upload_repository.

Closes #1 