### PR TITLE
Workflows: Upgrade to tuf-on-ci 0.5

### DIFF
--- a/.github/workflows/create-signing-events.yml
+++ b/.github/workflows/create-signing-events.yml
@@ -15,6 +15,19 @@ jobs:
       actions: 'write' # for dispatching signing event workflow
     steps:
       - name: Create signing events for offline version bumps
-        uses: theupdateframework/tuf-on-ci/actions/create-signing-events@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/create-signing-events@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [create-signing-events]
+    if: always() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -13,16 +13,28 @@ on:
 jobs:
   online-sign:
     runs-on: ubuntu-latest
-
     permissions:
       id-token: 'write' # for OIDC identity access
       contents: 'write' # for commiting snapshot/timestamp changes
       actions: 'write' # for dispatching publish workflow
-
     steps:
       - id: online-sign
-        uses: theupdateframework/tuf-on-ci/actions/online-sign@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/online-sign@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
           gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [online-sign]
+    if: always() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: build-and-upload-repository
-        uses: theupdateframework/tuf-on-ci/actions/upload-repository@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/upload-repository@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           gh_pages: true
           ref: ${{ inputs.ref }}
@@ -35,3 +35,22 @@ jobs:
       - name: Deploy TUF-on-CI repository to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@7a9bd943aa5e5175aeb8502edcc6c1c02d398e10 # v4.0.2
+
+  test-deployed-repository:
+    needs: deploy
+    permissions:
+      issues: 'write' # for modifying Issues
+    uses: ./.github/workflows/test.yml
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [build, deploy, test-deployed-repository]
+    if: always() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/signing-event.yml
+++ b/.github/workflows/signing-event.yml
@@ -19,6 +19,6 @@ jobs:
 
     steps:
       - name: Signing event
-        uses: theupdateframework/tuf-on-ci/actions/signing-event@ecbe81ad94615bfb2d133a022db383c80d782038 # v0.4.0
+        uses: theupdateframework/tuf-on-ci/actions/signing-event@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: TUF-on-CI repository tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4,10,16,22 * * *'
+
+permissions: {}
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Smoke test TUF-on-CI repository with a TUF client
+        uses: theupdateframework/tuf-on-ci/actions/test-repository@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [smoke-test]
+    # During workflow_call, caller updates issue
+    if: always() && !cancelled() && github.workflow == 'test.yml'
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}


### PR DESCRIPTION
Upgrade to tuf-on-ci 0.5


These workflow changes come from tuf-on-ci-template: https://github.com/theupdateframework/tuf-on-ci-template/:
* New job in each workflow to file issues if a workflow fails
* New reusable workflow to run smoke tests
  * called on schedule
  * called during publish

--- 

I had planned to add a sigstore client test in this same PR  (see #32) but it requires some test runs  and I can't do those before the test workflow is in main. The test workflow is useful already as it tests that the repository is a working TUF repository
