### PR TITLE
workflows: Add a custom test workflow

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -1,0 +1,37 @@
+name: root-signing repository tests with a Sigstore client
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  custom-test:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
+    steps:
+      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Install sigstore-python, tweak it to use the published TUF repository
+        run: |
+          pip install sigstore
+
+          # tweak sigstore sources to use our publish URL
+          SITE_PACKAGES=$(pip show sigstore | sed -n "s/^Location: //p")
+          TUF_PY="$SITE_PACKAGES/sigstore/_internal/tuf.py"
+          PUBLISH_URL="https://sigstore.github.io/root-signing-staging/"
+
+          sed -ie "s#^STAGING_TUF_URL = .*#STAGING_TUF_URL = \"$PUBLISH_URL\"#" "$TUF_PY"
+
+      - name: Test published repository with a Sigstore client
+        run: |
+          touch artifact
+          # sign, then verify using the Actions oidc identity
+          python -m sigstore -vv --staging sign artifact
+
+          python -m sigstore --staging verify github \
+              --cert-identity $GITHUB_SERVER_URL/$GITHUB_WORKFLOW_REF \
+              artifact

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,14 @@ jobs:
       - name: Smoke test TUF-on-CI repository with a TUF client
         uses: theupdateframework/tuf-on-ci/actions/test-repository@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
 
+  custom-smoke-test:
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
+    uses: ./.github/workflows/custom-test.yml
+
   update-issue:
     runs-on: ubuntu-latest
-    needs: [smoke-test]
+    needs: [smoke-test, custom-smoke-test]
     # During workflow_call, caller updates issue
     if: always() && !cancelled() && github.workflow == 'test.yml'
     permissions:


### PR DESCRIPTION
workflows: Add a smoke test that uses a sigstore client 

This makes sure that the repository we have published to Pages works as a Sigstore Staging root-signing repository:
* installs sigstore-python
* modifies sources to use our TUF URL (this is not yet exposed in sigstore-python CLI)
* runs sign & verify: sigstore-python will update metadata from our published TUF repository

This does not actually check that the client has received the expected metadata versions but the tuf-on-ci test has already tested that the published repository versions match expected versions.

Fixes #32 