### PR TITLE
workflows: Fix the smoke test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,14 @@ jobs:
     steps:
       - name: Smoke test TUF-on-CI repository with a TUF client
         uses: theupdateframework/tuf-on-ci/actions/test-repository@4ae5fdf2b18c6256787df167fce7a0e2d7e7a40e # v0.5.0
+        with:
+          metadata_url: https://sigstore.github.io/root-signing-staging/
 
   update-issue:
     runs-on: ubuntu-latest
     needs: [smoke-test]
     # During workflow_call, caller updates issue
-    if: always() && !cancelled() && github.workflow == 'test.yml'
+    if: always() && !cancelled() && github.workflow == 'TUF-on-CI repository tests'
     permissions:
       issues: 'write' # for modifying Issues
     steps:


### PR DESCRIPTION
Tweaks to the smoke test that was added yesterday.
* a missed configuration change for root-signing publishing directory structure
* a bug in tuf-on-ci-template: It's annoying that we have to resort to workflow name matching but it seems to be the only possibility without significantly more complex code (the purpose of the condition is to avoid filing an issue in both calling workflow and this workflow during `workflow_call`)

Fixes #36 .