### PR TITLE
Add a GCS deploy workflow

### DIFF
--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -1,0 +1,50 @@
+name: Deploy repository to GCS
+
+on:
+  workflow_call:
+    inputs:
+      gcp_workload_identity_provider:
+        required: true
+        type: string
+      gcp_service_account:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  deploy-to-gcs:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: 'write' # For authenticating with the GitHub workflow identity
+
+    steps:
+      - uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+        with:
+          name: github-pages
+
+      - name: Prepare data for upload
+        run: |
+          # Extract the github-pages arcive into ./repository/
+          mkdir repository
+          tar --directory repository -xvf artifact.tar
+
+      - uses: google-github-actions/auth@a6e2e39c0a0331da29f7fd2c2a20a427e8d3ad1f # v2.1.1
+        with:
+          token_format: access_token
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
+
+      - uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
+        with:
+          project_id: projectsigstore-staging
+
+      - name: Upload repository to GCS
+        run: |
+          # Upload metadata, make sure we upload timestamp last
+          mv repository/timestamp.json .
+          gcloud storage cp --cache-control=no-store -r repository/* gs://tuf-root-staging/
+          gcloud storage cp --cache-control=no-store timestamp.json gs://tuf-root-staging/
+
+          # invalidate CDN cache
+          gcloud compute url-maps invalidate-cdn-cache tuf-repo-cdn-lb --path "/*" --async

--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -41,10 +41,13 @@ jobs:
 
       - name: Upload repository to GCS
         run: |
+          BUCKET="gs://tuf-root-staging/"
+          LOAD_BALANCER="tuf-repo-cdn-lb"
+
           # Upload metadata, make sure we upload timestamp last
-          mv repository/timestamp.json .
-          gcloud storage cp --cache-control=no-store -r repository/* gs://tuf-root-staging/
-          gcloud storage cp --cache-control=no-store timestamp.json gs://tuf-root-staging/
+          gcloud storage rsync --cache-control=no-store --recursive --exclude=timestamp.json \
+              repository/ $BUCKET
+          gcloud storage cp --cache-control=no-store repository/timestamp.json $BUCKET
 
           # invalidate CDN cache
-          gcloud compute url-maps invalidate-cdn-cache tuf-repo-cdn-lb --path "/*" --async
+          gcloud compute url-maps invalidate-cdn-cache $LOAD_BALANCER --path "/*" --async

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,9 @@ jobs:
     permissions:
       id-token: 'write' # for authenticating with OIDC
     uses: ./.github/workflows/deploy-to-gcs.yml
+    with:
+      gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
   update-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,15 @@ jobs:
       id-token: 'write' # for signing with the GitHub Actions workflow identity
     uses: ./.github/workflows/test.yml
 
+  deploy-to-gcs:
+    needs: [test-deployed-repository]
+    permissions:
+      id-token: 'write' # for authenticating with OIDC
+    uses: ./.github/workflows/deploy-to-gcs.yml
+
   update-issue:
     runs-on: ubuntu-latest
-    needs: [build, deploy-to-pages, test-deployed-repository]
+    needs: [build, deploy-to-pages, test-deployed-repository, deploy-to-gcs]
     if: always() && !cancelled()
     permissions:
       issues: 'write' # for modifying Issues


### PR DESCRIPTION

Fixes #7

This uploads the repository to GCS and invalidates the CDN cache.

* the workflow is a custom one for root-signing
* it is called as a reusable workflow from the TUF-on-CI publish workflow (so gets automated issue failing on errors)

GCP configuration is mostly hard coded, only service account details are inputs:
 * service account: same as online signing
 * project: projectsigstore-staging
 * GCS bucket: tuf-root-staging
 * CDN load balancer: tuf-repo-cdn-lb
