### PR TITLE
Add tests for GCS publish

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -2,6 +2,10 @@ name: root-signing repository tests with a Sigstore client
 
 on:
   workflow_call:
+    inputs:
+      metadata_url:
+        description: "URL of the sigstore staging TUF repository to test"
+        required: true
 
 permissions: {}
 
@@ -10,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: 'write' # For signing with the GitHub workflow identity
+    env:
+      STAGING_URL: ${{ inputs.metadata_url }}
     steps:
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
@@ -20,11 +26,11 @@ jobs:
           pip install sigstore
 
           # tweak sigstore sources to use our publish URL
+          # TODO: remove this once sigstore-python supports "--tuf-url" or similar
           SITE_PACKAGES=$(pip show sigstore | sed -n "s/^Location: //p")
           TUF_PY="$SITE_PACKAGES/sigstore/_internal/tuf.py"
-          PUBLISH_URL="https://sigstore.github.io/root-signing-staging/"
 
-          sed -ie "s#^STAGING_TUF_URL = .*#STAGING_TUF_URL = \"$PUBLISH_URL\"#" "$TUF_PY"
+          sed -ie "s#^STAGING_TUF_URL = .*#STAGING_TUF_URL = \"$STAGING_URL\"#" "$TUF_PY"
 
       - name: Test published repository with sigstore-python
         run: |
@@ -38,11 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: 'write' # For signing with the GitHub workflow identity
+    env:
+      STAGING_URL: ${{ inputs.metadata_url }}
     steps:
       - uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 # v3.4.0
 
       - name: Download initial root
-        run: curl -o root.json https://sigstore.github.io/root-signing-staging/1.root.json
+        run: curl -o root.json ${STAGING_URL}/1.root.json
 
       - name: Test published repository with cosign
         run: |
@@ -50,7 +58,7 @@ jobs:
           touch artifact
 
           # initialize from the published repository
-          cosign initialize --root root.json --mirror https://sigstore.github.io/root-signing-staging/
+          cosign initialize --root root.json --mirror ${STAGING_URL}
 
           # sign, then verify using this workflows oidc identity
           cosign sign-blob \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@decdde0ac072f6dcbe43649d82d9c635fff5b4e4 # v4.0.4
 
-  test-deployed-repository:
+  test-deployed-pages:
     needs: deploy-to-pages
     permissions:
       issues: 'write' # for modifying Issues
@@ -44,7 +44,7 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   deploy-to-gcs:
-    needs: [test-deployed-repository]
+    needs: [test-deployed-pages]
     permissions:
       id-token: 'write' # for authenticating with OIDC
     uses: ./.github/workflows/deploy-to-gcs.yml
@@ -52,9 +52,17 @@ jobs:
       gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
       gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
 
+  test-deployed-gcs:
+    needs: [deploy-to-gcs]
+    if: always() && !failure() && !cancelled()
+    permissions:
+      issues: 'write' # for modifying Issues
+      id-token: 'write' # for signing with the GitHub Actions workflow identity
+    uses: ./.github/workflows/test-gcs.yml
+
   update-issue:
     runs-on: ubuntu-latest
-    needs: [build, deploy-to-pages, test-deployed-repository, deploy-to-gcs]
+    needs: [build, deploy-to-pages, test-deployed-pages, deploy-to-gcs, test-deployed-gcs]
     if: always() && !cancelled()
     permissions:
       issues: 'write' # for modifying Issues

--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -1,0 +1,40 @@
+name: root-signing GCS repository tests
+description: Verify with clients that the final deployment (on GCS) works
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 4,10,16,22 * * *'
+
+permissions: {}
+
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Smoke test Sigstore staging repository with a TUF client
+        uses: theupdateframework/tuf-on-ci/actions/test-repository@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0
+        with:
+          metadata_url: https://tuf-repo-cdn.sigstage.dev/
+
+  custom-smoke-test:
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
+    uses: ./.github/workflows/custom-test.yml
+    with:
+      metadata_url: https://tuf-repo-cdn.sigstage.dev/
+
+  update-issue:
+    runs-on: ubuntu-latest
+    needs: [smoke-test, custom-smoke-test]
+    # During workflow_call, caller updates issue
+    if: always() && !cancelled() && github.workflow == 'root-signing GCS repository tests'
+    permissions:
+      issues: 'write' # for modifying Issues
+    steps:
+      - name: Update the issue for the workflow
+        uses: theupdateframework/tuf-on-ci/actions/update-issue@3a44844ab0dc6883849df4039f8494b6f7b5386c # v0.7.0
+        with:
+          token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          success: ${{ !contains(needs.*.result, 'failure') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
     permissions:
       id-token: 'write' # For signing with the GitHub workflow identity
     uses: ./.github/workflows/custom-test.yml
+    with:
+      metadata_url: https://sigstore.github.io/root-signing-staging/
 
   update-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Summary

* We already test the GH Pages-published repo before the "real publish" to GCS
* We also want to test the GCS-published repo
* We especially want to test the GCS repo once #68 makes GCS upload more complicated

This PR implements tests for GCS published repo. Fixes #53.

This likely makes sense to merge before #68: This isn't really testable outside the repo so we'll need to merge and then test by:
* first manually dispatching online-sign -- this will dispatch publish and all tests
* then manually dispatching test-gcs.yml

#### Changes to workflows

1. Parametrize `custom-test` so that it can be used to test any URL.
1. Make an almost exact copy of `test`: The only difference is that `test-gcs` runs all tests against GCS and not GH Pages (this is not parametrized as we want to run these on schedule: it's unfortunately not possible to set inputs on schedule runs)
