### PR TITLE
workflows: Set missing input type

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -6,6 +6,7 @@ on:
       metadata_url:
         description: "URL of the sigstore staging TUF repository to test"
         required: true
+        type: string
 
 permissions: {}
 

--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -1,5 +1,4 @@
 name: root-signing GCS repository tests
-description: Verify with clients that the final deployment (on GCS) works
 
 on:
   workflow_call:


### PR DESCRIPTION
Fixes #71:
```
Error from called workflow sigstore/root-signing-staging/.github/workflows/custom-test.yml@185af8249bc4833c316af83a0f4fdb594805fc07 (Line: 7, Col: 9):
Required property is missing: type
```
Verifying changes around the testing is quite a lot of work so the original change and  this fix have not been tested in a running repository: If there are further issues with the actual test I will likely do the work of testing outside of root-signing-staging but this one seems simple enough to just yolo (the alternative is to revert #70 and try again later)