### PR TITLE
Add a signing event PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/signing_event.md
+++ b/.github/PULL_REQUEST_TEMPLATE/signing_event.md
@@ -1,0 +1,4 @@
+This is my signing event contribution.
+
+CC @sigstore/tuf-root-signing-staging-codeowners, please have a look
+and merge into the signing event branch.


### PR DESCRIPTION
The next signing tool release will try to use this template when non-maintainer signers submit their signatures.

---

Suggestions on the contents are welcome:
* its a bit vague since we don't really know if this is a signature or adding a key
* the main value is that we can add project specific info here like maintainer names (or potentially include whatever terms will trigger slack integration etc)

My plan is to release new tuf-on-ci as soon as theupdateframework/tuf-on-ci#209 is merged, and then start handling #74 here. If we have merged this before doing #74 we should see this template being used there.

