### PR TITLE
GCS Publish: Wait for CDN to invalidate

### DIFF
--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -49,5 +49,6 @@ jobs:
               repository/ $BUCKET
           gcloud storage cp --cache-control=no-store repository/timestamp.json $BUCKET
 
-          # invalidate CDN cache
-          gcloud compute url-maps invalidate-cdn-cache $LOAD_BALANCER --path "/*" --async
+          # invalidate CDN cache. This can take a while. We don't use "--async"
+          # because we want CDN to be testable when workflow finishes
+          gcloud compute url-maps invalidate-cdn-cache $LOAD_BALANCER --path "/*"


### PR DESCRIPTION
"invalidate-cdn-cache" can take a long time (at least 10 mins) to finish but we want to test the published repository so would rather wait.

I believe this fixes #84.

A better fix might involve a setup without cache invalidation: 
* The only thing we don't want to cache is timestamp.json: everything Elise can have a very long lifetime
* I wonder if serving timestamp.json without caching is expensive?
* alternatively would a short cache lifetime for timestamp work? does 10 seconds help at all? 1 minute?
