### PR TITLE
workflows: Remove cache invalidation from GCS deploy

### DIFF
--- a/.github/workflows/deploy-to-gcs.yml
+++ b/.github/workflows/deploy-to-gcs.yml
@@ -48,6 +48,3 @@ jobs:
           gcloud storage rsync --cache-control=no-store --recursive --exclude=timestamp.json \
               repository/ $BUCKET
           gcloud storage cp --cache-control=no-store repository/timestamp.json $BUCKET
-
-          # invalidate CDN cache
-          gcloud compute url-maps invalidate-cdn-cache $LOAD_BALANCER --path "/*" --async


### PR DESCRIPTION
* Negative caching is now disabled on staging: see https://github.com/sigstore/public-good-instance/pull/2167
* This means that both the 404 root request and the timestamp.json request that clients make are uncached and come from GCS
* Assumption is that this fixes #84 and test-repository action should now succeed immediately after deployment
* The production (sigstore-prober) failures in September 2023 are still unexplained but we want to test this setup in staging
