### PR TITLE
workflows: Use new test-repository features

### DIFF
--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -16,6 +16,8 @@ jobs:
         uses: theupdateframework/tuf-on-ci/actions/test-repository@ebf63d46b20e8c019e7752f8fb57c28931f96cfc # v0.9.0
         with:
           metadata_url: https://tuf-repo-cdn.sigstage.dev/
+          valid_days: 3
+          offline_valid_days: 30
 
   custom-smoke-test:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
         uses: theupdateframework/tuf-on-ci/actions/test-repository@ebf63d46b20e8c019e7752f8fb57c28931f96cfc # v0.9.0
         with:
           metadata_url: https://sigstore.github.io/root-signing-staging/
+          update_base_url: https://tuf-repo-cdn.sigstage.dev/
+          valid_days: 3
+          offline_valid_days: 30
 
   custom-smoke-test:
     permissions:


### PR DESCRIPTION
Use three new features of test-repository:

* update_base_url

During publish workflow we want to test that a client can update from current GCS (tuf-repo.cdn.sigstage.dev) to Pages
(sigstore.github.io/root-signing-staging/).

This test is done during cron runs as well but then it's usually not relevant (as the repos contents typically match).

* valid_days

We want a failure if either Pages or GCS repository is invalid in 3 days.

Note: sigstore-probers alerts when repository is invalid in 2 days

* offline_valid_days

We want a failure if root or targets in either Pages or GCS repository expires within 30 days.

Note: sigstore-probers alerts when offline roles expire in 15 days

--- 

Fixes #94 

I have test runs: 
* [test.yml](https://github.com/jku/root-signing-staging/actions/runs/8615129850/job/23609999672):
    ```
    # Run tuf-on-ci test client
    Testing repository at metadata-url https://sigstore.github.io/root-signing-staging/, artifact-url https://sigstore.github.io/root-signing-staging/targets/
    Client metadata update from base url https://tuf-repo-cdn.sigstage.dev/: OK
    Client metadata update from https://sigstore.github.io/root-signing-staging/ at reference time 2024-04-12 11:46:32: OK
    Client metadata matches sources: OK
    Role root is valid on 2024-05-09 11:46:32: OK
    Role targets is valid on 2024-05-09 11:46:32: OK
    ```

* [gcs-test.yml](https://github.com/jku/root-signing-staging/actions/runs/8615136167/job/23610019116)
    ```
    # Run tuf-on-ci test client
    Testing repository at metadata-url https://tuf-repo-cdn.sigstage.dev/, artifact-url https://tuf-repo-cdn.sigstage.dev/targets/
    Client metadata update from https://tuf-repo-cdn.sigstage.dev/ at reference time 2024-04-12 11:46:57: OK
    Client metadata matches sources: OK
    Role root is valid on 2024-05-09 11:46:57: OK
    Role targets is valid on 2024-05-09 11:46:57: OK
```