### PR TITLE
workflows: Add test for sigstore-go

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -8,15 +8,15 @@ on:
         required: true
         type: string
 
-permissions: {}
+permissions:
+  id-token: 'write' # For signing with the GitHub workflow identity
+
+env:
+  STAGING_URL: ${{ inputs.metadata_url }}
 
 jobs:
   sigstore-python:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: 'write' # For signing with the GitHub workflow identity
-    env:
-      STAGING_URL: ${{ inputs.metadata_url }}
     steps:
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
         with:
@@ -41,12 +41,14 @@ jobs:
           python -m sigstore -vv --staging sign artifact
           python -m sigstore --staging verify github --cert-identity $IDENTITY artifact
 
+      - name: Upload the bundle for other clients to verify
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: bundle
+          path: artifact.sigstore
+
   cosign:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: 'write' # For signing with the GitHub workflow identity
-    env:
-      STAGING_URL: ${{ inputs.metadata_url }}
     steps:
       - uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 # v3.5.0
 
@@ -75,3 +77,36 @@ jobs:
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               --bundle bundle.json \
               artifact
+
+  sigstore-go:
+    runs-on: ubuntu-latest
+    needs: [sigstore-python]
+    steps:
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        with:
+          go-version: '1.22'
+          check-latest: true
+
+      - name: Install sigstore-go
+        run: go install github.com/sigstore/sigstore-go/cmd/sigstore-go@latest
+
+      - name: Download initial root
+        run: curl -o root.json ${STAGING_URL}/1.root.json
+
+      - name: Download bundle to verify
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
+        with:
+          name: bundle
+
+      - name: Test published repository with sigstore-go
+        run: |
+          IDENTITY="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/.github/workflows/custom-test.yml@$GITHUB_REF"
+          touch artifact
+
+          ~/go/bin/sigstore-go \
+              -tufRootURL $STAGING_URL \
+              -tufTrustedRoot root.json \
+              -expectedSAN $IDENTITY \
+              -expectedIssuer https://token.actions.githubusercontent.com \
+              -artifact artifact \
+              artifact.sigstore


### PR DESCRIPTION
This is part of #79. Fixes #91.
* I'm not super happy about making the custom-test.yml longer and more complicated but we can try this
* I don't know what the correct method of installing go apps is but this seems to work?