### PR TITLE
workflows: Make sure custom-test.yml can run twice

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           name: bundle
           path: artifact.sigstore
+          overwrite: true
 
   cosign:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Publish workflow wants to call custom-test reusable workflow twice. This currently fails because both runs want to upload artifact 'bundle'.

We don't really care about the specific artifact so can just allow overwriting.

Fixes #102

--- 

This issue appeared from #99 (which started uploading the artifact for new client tests)