### PR TITLE
custom-test workflow: Tweak java client install

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -156,10 +156,11 @@ jobs:
         with:
           repository: "sigstore/sigstore-java"
           fetch-tags: true
+          fetch-depth: 0
 
       - name: Build cli from latest release tag, unpack distribution
         run: |
-          git checkout $(git describe --tags --match="v[0-9]*" HEAD)
+          git checkout $(git describe --tags --match="v[0-9]*" --abbrev=0 HEAD)
           ./gradlew :sigstore-cli:build
           tar -xvf sigstore-cli/build/distributions/sigstore-cli-*.tar --strip-components 1
 


### PR DESCRIPTION
Try harder to install the latest release of sigstore-java
* The checkout on GitHub Actions did not have tags (even though we use "fetch-tags: true")
* It seems current git describe needs --abbrev=0 to not give a non-tag result like v0.11.0-36-ga8c1fc3

Fixes #152 
