### PR TITLE
Avoid running signing-event workflow in forks

### DIFF
--- a/.github/workflows/signing-event.yml
+++ b/.github/workflows/signing-event.yml
@@ -19,6 +19,7 @@ jobs:
 
     steps:
       - name: Signing event
+        if: github.repository_owner == 'sigstore' # avoid running in forks
         uses: theupdateframework/tuf-on-ci/actions/signing-event@89d2dad3c8b626dde7a9e65b036ca35d11ab8b2a # v0.12.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This came up in root-signing prod signing event: Signers may have actions enabled in their forks. This leads to signing event workflow running in their fork. The results may be very strange as they depend on the state of main (which on forks may be years old).

Avoid running the signing-event workflow in forks.

Fixes #173 