### PR TITLE
tests: Lower the required validity time

### DIFF
--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           metadata_url: https://tuf-repo-cdn.sigstage.dev/
           valid_days: 3
-          offline_valid_days: 30
+          offline_valid_days: 16
 
   custom-smoke-test:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           metadata_url: https://sigstore.github.io/root-signing-staging/
           update_base_url: https://tuf-repo-cdn.sigstage.dev/
           valid_days: 3
-          offline_valid_days: 30
+          offline_valid_days: 16
 
   custom-smoke-test:
     permissions:


### PR DESCRIPTION
currently the signing periods are 32 days.
If we require metadata to to be valid for 30 days, then there is only 2 days signing time before there is a test failure.

Lower this to 16 days: That way we get a test failure if the signing has not happened in half the signing period -- this is still good to have in case of e.g. signing event creation failure.

See #177 for an example