### PR TITLE
Workflows: Make sure publish does not fail easily

### DIFF
--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -16,8 +16,9 @@ jobs:
         uses: theupdateframework/tuf-on-ci/actions/test-repository@89d2dad3c8b626dde7a9e65b036ca35d11ab8b2a # v0.12.0
         with:
           metadata_url: https://tuf-repo-cdn.sigstage.dev/
-          valid_days: 3
-          offline_valid_days: 16
+          # when workflow is reused in publish.yml, do not require future validity
+          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 3 }}
+          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 16 }}
 
   custom-smoke-test:
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,9 @@ jobs:
         with:
           metadata_url: https://sigstore.github.io/root-signing-staging/
           update_base_url: https://tuf-repo-cdn.sigstage.dev/
-          valid_days: 3
-          offline_valid_days: 16
+          # when workflow is reused in publish.yml, do not require future validity
+          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 3 }}
+          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 16 }}
 
   custom-smoke-test:
     permissions:


### PR DESCRIPTION
Tests can currently prevent publish from failing if the metadata is valid but just short lived: We do not want that, especially we do not want timestamp/snapshot updates being blocked because root will expire in 3 weeks.

Make sure the future validity checks are not done when reusing test.yml/test-gcs.yml workflow from publish.yml. Publish still makes sure the repository is valid and passes all client tests.

---

Fixes the underlying issue for #177