### PR TITLE
client tests: Test with an older cosign

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -78,6 +78,38 @@ jobs:
               --bundle bundle.json \
               artifact
 
+  cosign-old-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382 # v3.6.0
+        with:
+          cosign-release: "v2.2.0"
+
+      - name: Download initial root
+        run: curl -o root.json ${STAGING_URL}/1.root.json
+
+      - name: Test published repository with cosign 2.2
+        run: |
+          touch artifact
+
+          # initialize from the published repository
+          cosign initialize --root root.json --mirror ${STAGING_URL}
+
+          # sign, then verify using this workflows oidc identity
+          cosign sign-blob \
+              --yes \
+              --fulcio-url https://fulcio.sigstage.dev \
+              --oidc-issuer https://oauth2.sigstage.dev/auth \
+              --rekor-url https://rekor.sigstage.dev \
+              --bundle bundle.json \
+              artifact
+
+          cosign verify-blob \
+              --certificate-identity $IDENTITY \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --bundle bundle.json \
+              artifact
+
   sigstore-go:
     runs-on: ubuntu-latest
     needs: [sigstore-python]


### PR DESCRIPTION
It would be nice to have full matrix of clients and versions but maintainer resources are limited... so let's just add an older version of the most used client.

Fixes #172