### PR TITLE
workflows: Run tests when workflows change in PRs

### DIFF
--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '17 4,10,16,22 * * *'
+  pull_request:
+    paths: ['.github/workflows/*']
 
 permissions: {}
 
@@ -31,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [smoke-test, custom-smoke-test]
     # During workflow_call, caller updates issue
-    if: always() && !cancelled() && github.workflow == 'root-signing GCS repository tests'
+    if: always() && !cancelled() && github.workflow == 'root-signing GCS repository tests' && github.event_name != 'pull_request'
     permissions:
       issues: 'write' # for modifying Issues
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '17 4,10,16,22 * * *'
+  pull_request:
+    paths: ['.github/workflows/*']
 
 permissions: {}
 
@@ -31,8 +33,8 @@ jobs:
   update-issue:
     runs-on: ubuntu-latest
     needs: [smoke-test, custom-smoke-test]
-    # During workflow_call, caller updates issue
-    if: always() && !cancelled() && github.workflow == 'TUF-on-CI repository tests'
+    # During workflow_call, caller updates issue. During pull_request, issue updates are not needed
+    if: always() && !cancelled() && github.workflow == 'TUF-on-CI repository tests' && github.event_name != 'pull_request'
     permissions:
       issues: 'write' # for modifying Issues
     steps:


### PR DESCRIPTION
This is useful mostly as a smoke test for tuf-on-ci upgrade PRs (and would have prevented #210).

Running both test.yml and test-gcs.yml might not be that useful but keeping the workflows identical is likely valuable.

I'm leaving this a draft for now: I think there's a small bug in the test workflow I want to test first:
* `github.event_name == 'workflow_call'` is used in the workflow but I have a faint recollection that this will never happen: GitHub actually replaces event_name with the calling workflows triggering event (this is why `github.workflow` is used later in the workflow)