### PR TITLE
Extend timestamp validity check

### DIFF
--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           metadata_url: https://tuf-repo-cdn.sigstage.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 5 }}
-          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 16 }}
+          valid_days:  ${{ github.workflow == 'root-signing GCS repository tests' && 5 || 0 }}
+          offline_valid_days: ${{ github.workflow == 'root-signing GCS repository tests' && 16 || 0 }}
 
   custom-smoke-test:
     permissions:

--- a/.github/workflows/test-gcs.yml
+++ b/.github/workflows/test-gcs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           metadata_url: https://tuf-repo-cdn.sigstage.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 3 }}
+          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 5 }}
           offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 16 }}
 
   custom-smoke-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           metadata_url: https://sigstore.github.io/root-signing-staging/
           update_base_url: https://tuf-repo-cdn.sigstage.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 3 }}
+          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 5 }}
           offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 16 }}
 
   custom-smoke-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
           metadata_url: https://sigstore.github.io/root-signing-staging/
           update_base_url: https://tuf-repo-cdn.sigstage.dev/
           # when workflow is reused in publish.yml, do not require future validity
-          valid_days:  ${{ github.event_name == 'workflow_call' && 0 || 5 }}
-          offline_valid_days: ${{ github.event_name == 'workflow_call' && 0 || 16 }}
+          valid_days:  ${{ github.workflow == 'TUF-on-CI repository tests' && 5 || 0 }}
+          offline_valid_days: ${{ github.workflow == 'TUF-on-CI repository tests' && 16 || 0 }}
 
   custom-smoke-test:
     permissions:


### PR DESCRIPTION
This combines two related changes:
* Fix #216: currently publishing requires validity in the future because of a bug: we do not want that since it creates tricky situations where some metadata cannot be updated if another metadata is expiring soon. The fix is a bit hacky but seems to work.
* Extend the required validity time for online signatures (timestamp) from 3 days to 5. This is https://github.com/sigstore/root-signing/issues/1415 and is useful since it gives us more time to react to issues with online signing

More details in commit messages for those interested.