### PR TITLE
Add Pre submit client tests iwth local trusted root and signing config

### DIFF
--- a/.github/workflows/test-local-root.yml
+++ b/.github/workflows/test-local-root.yml
@@ -1,4 +1,4 @@
-name: Test with PR root
+name: Test with PR trusted root and singing config.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Addresses #269  

Adds PR tests against the clients that can accept a local trusted_root.json and singing_config.json, or trust_config.json (python and sigstore-go, so far) against the PR's copy of those files. This ensures compatibility with file layouts, key types, hosts, etc.

Currently the tests run against the latest release of those clients.

 - The sigstore-go test is currently failing because it's not yet using the new version of protobuf-specs that include the `operator` field.
   - https://github.com/sigstore/root-signing-staging/actions/runs/15569497275/job/43841741611?pr=278#step:5:18 

- A maintainer probably needs to [approve](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#enabling-workflows-for-forks-of-private-repositories) the run to allow `id-token: write`. These changes are [working on my fork](https://github.com/ramonpetgrave64/root-signing-staging/pull/1).
  - https://github.com/sigstore/root-signing-staging/actions/runs/15569497275/job/43841741596#step:6:110  

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Adds PR tests against the clients that can accept a local trusted_root.json and singing_config.json, or trust_config.json (python and sigstore-go, so far) against the PR's copy of those files.


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

None
