### PR TITLE
workflows: Use newest go in sigstore-go test

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -115,9 +115,6 @@ jobs:
     needs: [sigstore-python]
     steps:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
-        with:
-          go-version: '1.22'
-          check-latest: true
 
       - name: Install sigstore-go
         run: go install github.com/sigstore/sigstore-go/examples/sigstore-go-verification@latest


### PR DESCRIPTION
go 1.22 is not correct anymore, the tests can fail (see https://github.com/sigstore/root-signing/issues/1535).

