### PR TITLE
test workflow: New cosign no longer wants URLs

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -69,13 +69,11 @@ jobs:
           # sign, then verify using this workflows oidc identity
           cosign sign-blob \
               --yes \
-              --fulcio-url https://fulcio.sigstage.dev \
-              --oidc-issuer https://oauth2.sigstage.dev/auth \
-              --rekor-url https://rekor.sigstage.dev \
               --bundle bundle.json \
               artifact
 
           cosign verify-blob \
+              --use-signed-timestamps=true \
               --certificate-identity $IDENTITY \
               --certificate-oidc-issuer https://token.actions.githubusercontent.com \
               --bundle bundle.json \


### PR DESCRIPTION
* urls are not needed/wanted anymore with "sign"
* but apparently --use-signed-timestamps=true is needed with "verify"

Fixes #330

tested in https://github.com/jku/root-signing-staging/actions/runs/18835538251