### PR TITLE
Add ruby test

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -225,10 +225,10 @@ jobs:
 
       - name: Download and configure initial root
         run: |
-          curl -o root.json ${METADATA_URL}/1.root.json
+          curl -o root.json ${STAGING_URL}/1.root.json
           METADATA_DIR=$(mktemp -d -t root-signing-ruby-test.XXXXXX)
           sigstore-cli tuf init root.json --metadata-dir=${METADATA_DIR}
-          sigstore-cli tuf refresh --metadata-dir=${METADATA_DIR} --metadata-url=${METADATA_URL}
+          sigstore-cli tuf refresh --metadata-dir=${METADATA_DIR} --metadata-url=${STAGING_URL}
 
       - name: Download bundle to verify
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0


### PR DESCRIPTION
This is a continuation of https://github.com/sigstore/root-signing/pull/1571 that I  ended up reverting in root-signing.
* the mktemp issue has been fixed
* also had to change the url env variable name (the names should really be the same but for some reason ended up being different in root-signing and root-signing-staging custom-test)

I'm leaving this a draft as there is still a failure when testing manually in my fork, `sigstore-cli verify` fails:

```
I, [2025-11-27T10:24:16.641219 #2012]  INFO -- : Copying root.json from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/data/_store/prod/root.json to /home/runner/.local/share/sigstore-ruby/sigstore/tuf/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/root.json
I, [2025-11-27T10:24:16.641415 #2012]  INFO -- : Copying trusted_root.json from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/data/_store/prod/trusted_root.json to /home/runner/.cache/sigstore-ruby/sigstore/tuf/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/trusted_root.json
W, [2025-11-27T10:24:16.647172 #2012]  WARN -- : Unknown key_id="fdfa83a07b5a83589b87ded41f77f39d232ad91f7cce52868dacd06ba089849f" in signatures for root
W, [2025-11-27T10:24:16.647206 #2012]  WARN -- : Unknown key_id="e2f59acb9488519407e18cbfc9329510be03c04aca9929d2f0301343fec85523" in signatures for root
W, [2025-11-27T10:24:16.647223 #2012]  WARN -- : Unknown key_id="3c344aa068fd4cc4e87dc50b612c02431fbc771e95003993683a2b0bf260cf0e" in signatures for root
W, [2025-11-27T10:24:16.647234 #2012]  WARN -- : Unknown key_id="ec81669734e017996c5b85f3d02c3de1dd4637a152019fe1af125d2f9368b95e" in signatures for root
W, [2025-11-27T10:24:16.647244 #2012]  WARN -- : Unknown key_id="1e1d65ce98b10addad4764febf7dda2d0436b3d3a3893579c0dddaea20e54849" in signatures for root
W, [2025-11-27T10:24:16.757076 #2012]  WARN -- : Unknown key_id="183e64f37670dc13ca0d28995a3053f3740954ddce44321a41e46534cf44e632" in signatures for root
W, [2025-11-27T10:24:16.757139 #2012]  WARN -- : Unknown key_id="6f260089d5923daf20166ca657c543af618346ab971884a99962b01988bbe0c3" in signatures for root
I, [2025-11-27T10:24:16.844235 #2012]  INFO -- : Downloaded 6494e21ea73fa7ee769f85f57d5a3e6a08725eae1e38c755fc3517c9e6bc0b66.trusted_root.json to /home/runner/.cache/sigstore-ruby/sigstore/tuf/https%3A%2F%2Ftuf-repo-cdn.sigstore.dev/trusted_root.json
W, [2025-11-27T10:24:16.846890 #2012]  WARN -- : Skipping unrecognized key type: PKIX_ED25519
Verifying artifact...
W, [2025-11-27T10:24:16.849743 #2012]  WARN -- : OpenSSL::X509::Store on this version of openssl (3.1.0) does not set time properly, this breaks TSA verification
/opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/internal/keyring.rb:30:in `block in verify': key not found: "d32f30a3c32d639c2b762205a21c7bb07788e68283a4ae6f42118723a1bea496", known: ["c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"] (KeyError)
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/internal/keyring.rb:30:in `fetch'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/internal/keyring.rb:30:in `verify'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/rekor/checkpoint.rb:75:in `block in verify'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/rekor/checkpoint.rb:68:in `each'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/rekor/checkpoint.rb:68:in `verify'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/rekor/checkpoint.rb:102:in `verify_checkpoint'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-0.2.2/lib/sigstore/verifier.rb:88:in `verify'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-cli-0.2.2/lib/sigstore/cli.rb:65:in `block in verify'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-cli-0.2.2/lib/sigstore/cli.rb:64:in `all?'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-cli-0.2.2/lib/sigstore/cli.rb:64:in `verify'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/thor-1.4.0/lib/thor/command.rb:28:in `run'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/thor-1.4.0/lib/thor/invocation.rb:127:in `invoke_command'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/thor-1.4.0/lib/thor.rb:538:in `dispatch'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/thor-1.4.0/lib/thor/base.rb:584:in `start'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-cli-0.2.2/lib/sigstore/cli.rb:13:in `start'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/lib/ruby/gems/3.2.0/gems/sigstore-cli-0.2.2/exe/sigstore-cli:5:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/bin/sigstore-cli:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.2.9/x64/bin/sigstore-cli:25:in `<main>'
```