### PR TITLE
workflows: Update service accounts

### DIFF
--- a/.github/workflows/online-sign.yml
+++ b/.github/workflows/online-sign.yml
@@ -22,8 +22,8 @@ jobs:
         uses: theupdateframework/tuf-on-ci/actions/online-sign@daa76c3dbf011b70f9fb01dbb989a27bbd2bd20d # v0.19.0
         with:
           token: ${{ secrets.TUF_ON_CI_TOKEN || secrets.GITHUB_TOKEN }}
-          gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          gcp_workload_identity_provider: 'projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+          gcp_service_account: 'tuf-signer@projectsigstore-staging.iam.gserviceaccount.com'
 
 
   update-issue:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,8 @@ jobs:
       id-token: 'write' # for authenticating with OIDC
     uses: ./.github/workflows/deploy-to-gcs.yml
     with:
-      gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      gcp_workload_identity_provider: 'projects/306323169285/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-provider'
+      gcp_service_account: 'tuf-publisher@projectsigstore-staging.iam.gserviceaccount.com'
 
   test-deployed-gcs:
     needs: [deploy-to-gcs]


### PR DESCRIPTION
Use separate service accounts for signing and publishing. This allows better separation of permissions.

The repository variables were used with the idea that the service account is then defined in only one place: that is no longer useful (since the service accounts are not the same) so we can just make the service accounts visible in the workflows.
