### PR TITLE
Add signing_config_rekor_v2.v0.2.json target

### DIFF
--- a/targets/signing_config_rekor_v2.v0.2.json
+++ b/targets/signing_config_rekor_v2.v0.2.json
@@ -1,0 +1,75 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json",
+  "caUrls": [
+    {
+      "url": "https://fulcio.sigstage.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2022-04-14T21:38:40Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "oidcUrls": [
+    {
+      "url": "https://oauth2.sigstage.dev/auth",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-04-16T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogUrls": [
+    {
+      "url": "https://log2025-alpha3.rekor.sigstage.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2025-09-22T11:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    },
+    {
+      "url": "https://log2025-alpha2.rekor.sigstage.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2025-08-20T07:24:08Z",
+        "end": "2025-09-22T11:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    },
+    {
+      "url": "https://log2025-alpha1.rekor.sigstage.dev",
+      "majorApiVersion": 2,
+      "validFor": {
+        "start": "2025-05-07T12:00:00Z",
+        "end": "2025-08-20T07:24:08Z"
+      },
+      "operator": "sigstore.dev"
+    },
+    {
+      "url": "https://rekor.sigstage.dev",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2021-01-12T11:53:27Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "tsaUrls": [
+    {
+      "url": "https://timestamp.sigstage.dev/api/v1/timestamp",
+      "majorApiVersion": 1,
+      "validFor": {
+        "start": "2025-04-09T00:00:00Z"
+      },
+      "operator": "sigstore.dev"
+    }
+  ],
+  "rekorTlogConfig": {
+    "selector": "ANY"
+  },
+  "tsaConfig": {
+    "selector": "ANY"
+  }
+}


### PR DESCRIPTION
Production TUF serves a signing_config_rekor_v2.v0.2.json target but staging does not. cosign's `--with-default-rekor-v2` flag fetches that target by exact name with no fallback to signing_config.v0.2.json (pkg/cosign/tuf.go), so SigningConfigRekorV2() resolves against production but errors out against the sigstage.dev TUF. This forces clients trialing Rekor v2 to branch on staging vs. production instead of calling the same API everywhere.

This duplicates the existing signing_config.v0.2.json — which already contains the Rekor v2 URLs — under the new name, matching the production layout. Keeping it a byte-for-byte copy means the existing testing infra needs no changes. The TUF-on-CI signing event triggered on merge will register the target in metadata.

Per the issue discussion this targets sign/sc-rekor-v2 and should land after #413.

Fixes https://github.com/sigstore/root-signing-staging/issues/414

Assisted by Claude Opus 4.8