### PR TITLE
workflows: Tweak test permissions to be like prod

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -8,8 +8,7 @@ on:
         required: true
         type: string
 
-permissions:
-  id-token: 'write' # For signing with the GitHub workflow identity
+permissions: {}
 
 env:
   STAGING_URL: ${{ inputs.metadata_url }}
@@ -17,6 +16,8 @@ env:
 
 jobs:
   sigstore-python:
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -52,6 +53,8 @@ jobs:
           overwrite: true
 
   cosign:
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
     runs-on: ubuntu-latest
     steps:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -80,6 +83,8 @@ jobs:
               artifact
 
   cosign-old-version:
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
     runs-on: ubuntu-latest
     steps:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
@@ -214,6 +219,8 @@ jobs:
               artifact
 
   sigstore-rust:
+    permissions:
+      id-token: 'write' # For signing with the GitHub workflow identity
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
This makes the root-signing and root-signing-staging test workflows more similar, making it easier to copy changes.