### PR TITLE
workflows: Don't block on cosign-old-version test

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -83,6 +83,9 @@ jobs:
               artifact
 
   cosign-old-version:
+    # https://github.com/sigstore/root-signing-staging/issues/431:
+    # cosign-old-version fails with multi-region infra: set continue-on-error
+    continue-on-error: true
     permissions:
       id-token: 'write' # For signing with the GitHub workflow identity
     runs-on: ubuntu-latest


### PR DESCRIPTION
Current multi-region setup is incompatible with cosign 2.2: #431. Make the cosign-old-version test not affect final test result while we decide how to proceed with this.
