### PR TITLE
Use Cosign v2.5.1 in cosign-old-version test

### DIFF
--- a/.github/workflows/custom-test.yml
+++ b/.github/workflows/custom-test.yml
@@ -83,21 +83,18 @@ jobs:
               artifact
 
   cosign-old-version:
-    # https://github.com/sigstore/root-signing-staging/issues/431:
-    # cosign-old-version fails with multi-region infra: set continue-on-error
-    continue-on-error: true
     permissions:
       id-token: 'write' # For signing with the GitHub workflow identity
     runs-on: ubuntu-latest
     steps:
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: "v2.2.0"
+          cosign-release: "v2.5.1"
 
       - name: Download initial root
         run: curl -o root.json ${STAGING_URL}/1.root.json
 
-      - name: Test published repository with cosign 2.2
+      - name: Test published repository with cosign 2.5
         run: |
           touch artifact
 


### PR DESCRIPTION
Closes #434 

#### Summary

This change updates Cosign in the `cosign-old-version` test to [v2.5.1](https://github.com/sigstore/cosign/releases/tag/v2.5.1), the earliest version that verifies using the trusted root provided by TUF, to support multi-region services.